### PR TITLE
Add missing semicolon

### DIFF
--- a/home-template.nix
+++ b/home-template.nix
@@ -93,7 +93,7 @@ let tools = [
         cat = "bat -p";
         hms = "home-manager switch --impure --flake $HOME/home-manager-config#$USER";
         hmsz = "home-manager switch --impure --flake $HOME/home-manager-config#$USER && source ~/.zshrc";
-        mfa = "awsmfa auth -u <user> -t"
+        mfa = "awsmfa auth -u <user> -t";
       };
 
       plugins = [


### PR DESCRIPTION
Author: Andhieka Putra

Reasons for Change:
 - Got error when activating home manager

```
❯ home-manager switch --impure --flake "home-manager-config#$USER"
error: syntax error, unexpected '}', expecting ';'

       at /nix/store/py7qy51z4m66qd2jrpxwszmaayhwg8hg-source/home-template.nix:97:7:

           96|         mfa = "awsmfa auth -u <user> -t"
           97|       };
             |       ^
           98|
(use '--show-trace' to show detailed location information)
```

Changes:
 -
